### PR TITLE
fix decoding of response from HNPWA API so it is read as UTF-8

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -18,7 +18,7 @@ class HnpwaClient {
     final response = await client.get(_buildUrl('item/$id.json'));
 
     if (response.statusCode == 200) {
-      return Item.fromJson(json.decode(response.body));
+      return Item.fromJson(_decodeResponse(response));
     } else {
       throw Exception(
         '${response.statusCode} Error Fetching HNPWA Results: ${response.body}',
@@ -30,7 +30,7 @@ class HnpwaClient {
     final response = await client.get(_buildUrl('user/$id.json'));
 
     if (response.statusCode == 200) {
-      return User.fromJson(json.decode(response.body));
+      return User.fromJson(_decodeResponse(response));
     } else {
       throw Exception(
         '${response.statusCode} Error Fetching HNPWA Results: ${response.body}',
@@ -97,8 +97,7 @@ class HnpwaClient {
 
     if (response.statusCode == 200) {
       return Feed.from(
-        items:
-            (json.decode(response.body) as List).cast<Map<String, dynamic>>(),
+        items: (_decodeResponse(response) as List).cast<Map<String, dynamic>>(),
         currentPage: currentPage,
         nextPage: currentPage < maxPages ? currentPage + 1 : null,
       );
@@ -108,4 +107,7 @@ class HnpwaClient {
       );
     }
   }
+
+  _decodeResponse(Response response) =>
+      json.decode(utf8.decode(response.bodyBytes));
 }


### PR DESCRIPTION
Whilst making use of the package, I had noticed that certain parts of the text weren't appearing properly.

For example, item 20043410 has a title of _The Boring Company will develop an underground “people mover” for Las Vegas_. However, the package returns the title as _The Boring Company will develop an underground â€œpeople moverâ€ for Las Vegas_. Looking at the response headers, it can be seen that the charset isn't being set. As such the fix here is to decode the response body in bytes UTF-8 as per the discussion [here](https://github.com/dart-lang/http/issues/175)